### PR TITLE
Formatting overhaul / misc cleanup

### DIFF
--- a/Hornet.py
+++ b/Hornet.py
@@ -1,16 +1,12 @@
-import discord
-from discord.ext import commands, tasks
-from discord.ext.commands import Context, errors
-import logging
-import time
+from discord import Game, Intents, Role, User
+from discord.ext import commands
+from discord.ext.commands import Bot, Command, Context
+from discord.utils import setup_logging
 from datetime import datetime, timedelta
-import os
-import asyncio
+import logging, os, time
 
 from components import auth, emojiUtil, helpcmd, embeds
-
-import config
-import save
+import config, save
 
 # Move old log and timestamp
 if not os.path.exists(config.LOG_FOLDER): os.mkdir(f"./{config.LOG_FOLDER}")
@@ -20,22 +16,22 @@ filehandler = logging.FileHandler(filename=config.LOG_PATH, encoding="utf-8", mo
 filehandler.setFormatter(logging.Formatter('[{asctime}] [{levelname:<8}] {name}: {message}', '%Y-%m-%d %H:%M:%S', style='{'))
 logging.getLogger().addHandler(filehandler) # file log
 
-discord.utils.setup_logging(level=logging.INFO) # add stream to stderr & set for discord.py
+setup_logging(level=logging.INFO) # add stream to stderr & set for discord.py
 
-def getParams(cmd: commands.Command):
+def get_params(cmd: Command):
     paramstring = ""
-    for name, param in cmd.params.items():
-        if not param.required: 
+    for param in cmd.params.values():
+        if not param.required:
             paramstring += f"*<{param.name}>* "
-        else: 
+        else:
             paramstring += f"<{param.name}> "
     return cmd.usage if cmd.usage is not None else paramstring
 
-class HornetBot(commands.Bot):
+class HornetBot(Bot):
     def __init__(self, *args, **kwargs):
         emojiUtil.bot = self
         # Intents (all)
-        intents = discord.Intents.default()
+        intents = Intents.default()
         intents.message_content = True
         intents.presences = True
         intents.members = True
@@ -49,13 +45,13 @@ class HornetBot(commands.Bot):
             if not file.endswith(".py"): continue
             mod_name = file[:-3]   # strip .py at the end
             modules.append(mod_name)
-            
+
         # Add extensions from /modules/
         for ext in modules:
             try:
                 await self.load_extension(f"modules.{ext}")
                 logging.info(f"Loaded {ext}")
-                save.initModule(ext)
+                save.init_module(ext)
                 logging.info(f"Module {ext} save template enforced")
             except commands.ExtensionError as e:
                 logging.error(f"Failed to load {ext}", exc_info=e)
@@ -63,7 +59,7 @@ class HornetBot(commands.Bot):
             except save.TemplateEnforcementError as e:
                 await self.unload_extension(ext)
                 logging.error(f"Module {ext} failed to enforce template in save.json, unloaded", exc_info=e)
-    
+
     async def on_command_error(self, ctx: Context, error: commands.CommandError):
         ectx = embeds.EmbedContext(ctx)
 
@@ -76,88 +72,95 @@ class HornetBot(commands.Bot):
             cmd = ctx.invoked_with
             cog = self.get_cog("CustomCommands")
             if cog and await cog.try_custom_cmd(ctx, cmd): return
-            await ectx.embedReply(title=f"Command {ctx.prefix}{cmd} not found")
+            await ectx.embed_reply(title=f"Command {ctx.prefix}{cmd} not found")
             return
-        
+
         if isinstance(error, commands.CheckFailure):
-            await ectx.embedReply(title="Not permitted", message="You are not allowed to run this command")
+            await ectx.embed_reply(title="Not permitted", message="You are not allowed to run this command")
             return
-        
+
         cmd = ctx.command
-        
+
         if isinstance(error, commands.UserInputError):
             if isinstance(error, commands.MissingRequiredArgument):
-                await ectx.embedReply(title=f"Command: {ctx.prefix}{cmd} {getParams(cmd)}", \
-                                        message=f"Required parameter `{error.param.name}` is missing")
+                await ectx.embed_reply(
+                    title=f"Command: {ctx.prefix}{cmd} {get_params(cmd)}",
+                    message=f"Required parameter `{error.param.name}` is missing"
+                )
                 return
             typename = type(error).__name__
             if typename.endswith("NotFound"):
                 typename = typename.removesuffix("NotFound")
-                await ectx.embedReply(title=f"{typename} not found", message=f"{typename} `{error.argument}` could not be found")
+                await ectx.embed_reply(
+                    title=f"{typename} not found",
+                    message=f"{typename} `{error.argument}` could not be found"
+                )
                 return
 
-        await ectx.embedReply(title=f"Unhandled exception in Hornet!", \
-                              message=f"```{error.args}```\r\nIf this message doesn't help, consider reporting to <@196347053100630016>")
+        await ectx.embed_reply(
+            title=f"Unhandled exception in Hornet!",
+            message=f"```{error.args}```\r\nIf this message doesn't help, consider reporting to <@196347053100630016>"
+        )
         return await super().on_command_error(ctx, error)
 
-botInstance = HornetBot(command_prefix =';', activity=discord.Game(name="Hollow Knight: Silksong"))
+bot_instance = HornetBot(command_prefix =';', activity=Game(name="Hollow Knight: Silksong"))
 
 # Base bot commands
-@botInstance.command(help="pong!", hidden=True)
+@bot_instance.command(help="pong!", hidden=True)
 async def ping(context: Context):
     await context.reply('pong!', mention_author=False)
 
-@botInstance.command(help="pong!", hidden=True)
+@bot_instance.command(help="ping!", hidden=True)
 async def pong(context: Context):
     await context.reply('ping!', mention_author=False)
 
-@botInstance.command(help="Time since bot went up", hidden=True)
+@bot_instance.command(help="Time since bot went up", hidden=True)
 async def uptime(context: Context):
-    await embeds.embedReply(context, title="Uptime:", message=f"{timedelta(seconds=int(time.time() - startTime))}")
+    await embeds.embed_reply(context, title="Uptime:", message=f"{timedelta(seconds=int(time.time() - start_time))}")
 
-@botInstance.command(help="Get user's avatar by id")
-async def avatar(context: Context, user: discord.User = None):
+@bot_instance.command(help="Get user's avatar by id")
+async def avatar(context: Context, user: User = None):
     if user is None: user = context.author
     await context.reply(user.display_avatar.url, mention_author=False)
 
-@botInstance.command(help="Add admin role (owner only)")
-@commands.check(auth.isOwner)
-async def addAdminRole(context: Context, role: discord.Role):
-    save.getGuildData(context.guild.id)["adminRoles"].append(role.id)
+@bot_instance.command(help="Add admin role (owner only)")
+@auth.check_owner
+async def addAdminRole(context: Context, role: Role):
+    save.get_guild_data(context.guild.id)["adminRoles"].append(role.id)
     save.save()
     await context.message.delete()
 
-@botInstance.command(help="Remove admin role (owner only)")
-@commands.check(auth.isOwner)
-async def removeAdminRole(context: Context, role: discord.Role):
-    save.getGuildData(context.guild.id)["adminRoles"].remove(role.id)
+@bot_instance.command(help="Remove admin role (owner only)")
+@auth.check_owner
+async def removeAdminRole(context: Context, role: Role):
+    save.get_guild_data(context.guild.id)["adminRoles"].remove(role.id)
     save.save()
     await context.message.delete()
 
-@botInstance.command(help="Set server nickname in save.json (global admin only)")
-@commands.check(auth.isGlobalAdmin)
+@bot_instance.command(help="Set server nickname in save.json (global admin only)")
+@auth.check_global_admin
 async def setNick(context: Context, nickname: str):
-    save.getGuildData(context.guild.id)["nick"] = nickname
+    save.get_guild_data(context.guild.id)["nick"] = nickname
     save.save()
     await context.message.delete()
 
-@botInstance.command(help="Reload modules (global admin only)")
-@commands.check(auth.isGlobalAdmin)
+@bot_instance.command(help="Reload modules (global admin only)")
+@auth.check_global_admin
 async def reloadModules(context: Context):
-    extensionNames = list(botInstance.extensions.keys())
+    extension_names = list(bot_instance.extensions.keys())
     failed = []
-    for extension in extensionNames:
+    for extension in extension_names:
         try:
-            await botInstance.reload_extension(extension, package="modules")
+            await bot_instance.reload_extension(extension, package="modules")
             logging.log(logging.INFO, f"Loaded {extension}")
         except commands.ExtensionError as e:
             logging.log(logging.ERROR, f"Failed to load {extension}; ignoring")
             logging.log(logging.ERROR, e)
             failed.append(extension)
-    if len(failed) == 0:
+    if not failed:
         await context.reply("Reloaded all modules!", mention_author=False)
     else:
         await context.reply(f"Modules {', '.join(failed)} failed to reload")
 
-startTime = time.time()
-botInstance.run(config.token)
+start_time = time.time()
+bot_instance.run(config.token)

--- a/components/auth.py
+++ b/components/auth.py
@@ -24,11 +24,8 @@ async def guild_exists(context: Context) -> bool:
         save.init_guild_data(context.guild.id)
     return True
 
-def check_admin() -> Check[Context]:
-    return check(is_admin)
+check_admin = check(is_admin)
 
-def check_owner() -> Check[Context]:
-    return check(is_owner)
+check_owner = check(is_owner)
 
-def check_global_admin() -> Check[Context]:
-    return check(is_global_admin)
+check_global_admin = check(is_global_admin)

--- a/components/auth.py
+++ b/components/auth.py
@@ -1,5 +1,4 @@
 from discord.ext.commands import Context, check
-from discord.ext.commands.core import Check
 
 import config, save
 

--- a/components/auth.py
+++ b/components/auth.py
@@ -1,25 +1,34 @@
-import discord
-from discord.ext import commands
+from discord.ext.commands import Context, check
+from discord.ext.commands.core import Check
 
-import save, config
+import config, save
 
-async def isAdmin(context: commands.Context) -> bool:
-    if not await guildExists(context): return False
+async def is_admin(context: Context) -> bool:
+    if not await guild_exists(context): return False
     if context.author.guild.owner == context.author: return True # server owner is an admin
     for role in context.author.roles:
         if role.id in save.data["guilds"][str(context.guild.id)]["adminRoles"]:
             return True
     return False
 
-async def isOwner(context: commands.Context) -> bool:
-    if not await guildExists(context): return False
+async def is_owner(context: Context) -> bool:
+    if not await guild_exists(context): return False
     if context.author.guild.owner == context.author: return True # server owner is an admin
     else: return False
 
-async def isGlobalAdmin(context: commands.Context) -> bool:
+async def is_global_admin(context: Context) -> bool:
     return context.author.id in config.admins
 
-async def guildExists(context: commands.Context) -> bool:
-    if str(context.guild.id) not in save.data["guilds"].keys():
-        save.initGuildData(context.guild.id)
+async def guild_exists(context: Context) -> bool:
+    if str(context.guild.id) not in save.data["guilds"]:
+        save.init_guild_data(context.guild.id)
     return True
+
+def check_admin() -> Check[Context]:
+    return check(is_admin)
+
+def check_owner() -> Check[Context]:
+    return check(is_owner)
+
+def check_global_admin() -> Check[Context]:
+    return check(is_global_admin)

--- a/components/embeds.py
+++ b/components/embeds.py
@@ -1,43 +1,31 @@
-import discord.embeds as e
 from discord.abc import Messageable
+from discord.embeds import Embed
 from discord.ext.commands import Context
 from discord.colour import Colour
 
 HORNET_COLOUR = Colour(0x79414B)
 
-class EmbedContext():
-    def __init__(self, context: Context):
-        self.context = context
-
-    async def embedMessage(self, message=None, title=None, fields=None):
-        construct = e.Embed(description=message, title=title, colour=HORNET_COLOUR)
-        if fields:
-            for f in fields:
-                inline = f[2] if len(f) == 3 else True
-                construct.add_field(name=f[0], value=f[1], inline=inline)
-        await self.context.send(embed=construct)
-
-    async def embedReply(self, message=None, title=None, fields=None):
-        construct = e.Embed(description=message, title=title, colour=HORNET_COLOUR)
-        if fields:
-            for f in fields:
-                inline = f[2] if len(f) == 3 else True
-                construct.add_field(name=f[0], value=f[1], inline=inline)
-        await self.context.reply(embed=construct, mention_author=False)
-
-async def embedReply(context : Context, message=None, title=None, fields=None):
-    construct = e.Embed(description=message, title=title, colour=HORNET_COLOUR)
+def get_embed(message=None, title=None, fields=None):
+    embed = Embed(description=message, title=title, colour=HORNET_COLOUR)
     if fields:
         for f in fields:
             inline = f[2] if len(f) == 3 else False
-            construct.add_field(name=f[0], value=f[1], inline=inline)
-    await context.reply(embed=construct, mention_author=False)
+            embed.add_field(name=f[0], value=f[1], inline=inline)
+    return embed
 
-async def embedMessage(dest: Messageable, message=None, title=None, fields=None):
+async def embed_reply(context: Context, message=None, title=None, fields=None):
+    await context.reply(embed=get_embed(message, title, fields), mention_author=False)
+
+async def embed_message(dest: Messageable, message=None, title=None, fields=None):
     """Send an embed message to the destination channel/context, with optional fields as a List[Tuple[str, str]]"""
-    construct = e.Embed(description=message, title=title, colour=HORNET_COLOUR)
-    if fields:
-        for f in fields:
-            inline = f[2] if len(f) == 3 else True
-            construct.add_field(name=f[0], value=f[1], inline=inline)
-    await dest.send(embed=construct)
+    await dest.send(embed=get_embed(message, title, fields))
+
+class EmbedContext:
+    def __init__(self, context: Context):
+        self.context = context
+
+    async def embed_reply(self, message=None, title=None, fields=None):
+        await embed_reply(self.context, message, title, fields)
+
+    async def embed_message(self, message=None, title=None, fields=None):
+        await embed_message(self.context, message, title, fields)

--- a/components/emojiUtil.py
+++ b/components/emojiUtil.py
@@ -1,13 +1,11 @@
 from typing import Union
-import discord
 from discord import Emoji, PartialEmoji
-from discord.ext.commands import EmojiConverter, EmojiNotFound, Context, Bot
-import discord.ext.commands.converter
+from discord.ext.commands import Bot, Context, EmojiConverter, EmojiNotFound
 import emoji
 
-bot : Bot = None  # set up in Hornet.py
+bot: Bot = None  # set up in Hornet.py
 
-async def toEmoji(ctx : Context, reference: str) -> Union[str, Emoji]:
+async def to_emoji(ctx: Context, reference: str) -> Union[str, Emoji]:
     """ID/emoji string to either Emoji or str if unicode emoji"""
     try:
         return await EmojiConverter().convert(ctx, reference)
@@ -15,13 +13,13 @@ async def toEmoji(ctx : Context, reference: str) -> Union[str, Emoji]:
         if is_emoji(reference): return reference # catch unicode emoji
         else: raise e
 
-def toString(emoji: Union[Emoji, str]) -> str:
+def to_string(emoji: Union[Emoji, str]) -> str:
     """Emoji client embed or unicode string"""
     if isinstance(emoji, str): return emoji
     if isinstance(emoji, PartialEmoji):
         if emoji.id is None: return emoji.name
     return f"<:{emoji.name}:{emoji.id}>"
 
-def is_emoji(codepoint : str):
+def is_emoji(codepoint: str):
     if 0x1F1E6 <= ord(codepoint) <= 0x1F1FF: return True
     return emoji.is_emoji(codepoint)

--- a/components/helpcmd.py
+++ b/components/helpcmd.py
@@ -1,93 +1,91 @@
-from typing import Any, Mapping, Optional, List
+from typing import Mapping, Optional, List
 from discord.ext import commands
-from discord.ext.commands import Cog, Command, HelpCommand
+from discord.ext.commands import Bot, Cog, Command, HelpCommand
 from discord.ext.commands.context import Context
-import discord
-import discord.embeds as e
 from discord.ext.commands.core import Command
-
 from discord.ext.commands._types import BotT
+from discord.utils import maybe_coroutine
 
 from components import embeds
 
 class HornetHelpCommand(HelpCommand):
-    def __init__(self, **options):
-        super().__init__(**options)
-
-    async def parseCommands(self, cmds : list[Command]) -> list[tuple]:
+    async def parse_commands(self, cmds: list[Command]) -> list[tuple]:
         """Parse commands from a list into a set of fields."""
-        cmdFields = []
+        cmd_fields = []
         for cmd in cmds:
             if await cmd.can_run(self.context) and not cmd.hidden:
-                cmdFields.append((f"{self.context.prefix}{cmd.qualified_name} {getParams(cmd)}", cmd.help if cmd.help is not None else "", False))
-        return sorted(cmdFields, key=lambda a: a[0])
+                cmd_fields.append((
+                    f"{self.context.prefix}{cmd.qualified_name} {get_params(cmd)}",
+                    cmd.help if cmd.help is not None else "",
+                    False
+                ))
+        return sorted(cmd_fields, key=lambda a: a[0])
 
     async def send_bot_help(self, mapping: Mapping[Optional[Cog], List[Command]]):
-        cmdFields = await self.parseCommands(mapping[None])
-        
-        cmdFields.append(("__Modules__", "Type ;help <module> for module commands", False))
-        
+        cmd_fields = await self.parse_commands(mapping[None])
+
+        cmd_fields.append(("__Modules__", "Type ;help <module> for module commands", False))
+
         modules = []
-        for cog in mapping:
+        for cog, cmds in mapping.items():
             if cog is None: continue
-            cmds = mapping[cog]
-            
             module_allowed = False
             for cmd in cmds:
                 if await cmd.can_run(self.context):
                     module_allowed = True
             if module_allowed:
                 modules.append((cog.qualified_name, cog.description, True))
-            
-        await embeds.embedMessage(self.get_destination(), title="Help", fields=cmdFields + modules)
+
+        await embeds.embed_message(self.get_destination(), title="Help", fields=cmd_fields + modules)
 
     async def send_cog_help(self, cog: Cog):
-        commandtuples = await self.parseCommands(cog.get_commands())
-        await embeds.embedMessage(self.get_destination(), title=f"Help: {cog.qualified_name} module", fields=commandtuples)
+        cmd_tuples = await self.parse_commands(cog.get_commands())
+        await embeds.embed_message(self.get_destination(), title=f"Help: {cog.qualified_name} module", fields=cmd_tuples)
 
     async def send_command_help(self, command: Command):
         aliases = f"*Aliases: {', '.join(command.aliases)}*\r\n" if len(command.aliases) > 0 else ""
-        helpmessage = command.description if command.description else (command.help if command.help else "")
-        await embeds.embedMessage(self.get_destination(), title=f"{self.context.prefix}{command.qualified_name} {getParams(command)}", \
-                                    message=aliases+helpmessage)
-    
+        help_message = command.description if command.description else (command.help if command.help else "")
+        await embeds.embed_message(
+            self.get_destination(),
+            title=f"{self.context.prefix}{command.qualified_name} {get_params(command)}",
+            message=aliases + help_message
+        )
+
     async def command_callback(self, ctx: Context[BotT], /, *, command: Optional[str] = None) -> None:
         """Override of default callback for case-insensitive cog help implementation"""
         await self.prepare_help_command(ctx, command)
 
-        bot : commands.Bot = ctx.bot
+        bot: Bot = ctx.bot
 
         if command is None:
             mapping = self.get_bot_mapping()
             return await self.send_bot_help(mapping)
 
         # Check if it's a cog
-        cogs = bot.cogs
-        cogs = {k.lower():v for (k, v) in bot.cogs.items()}
-        if command.lower() in cogs.keys():
-            return await self.send_cog_help(cogs[command.lower()])
-
-        maybe_coro = discord.utils.maybe_coroutine
+        cogs = {k.lower(): v for (k, v) in bot.cogs.items()}
+        cog = cogs.get(command.lower(), None)
+        if cog is not None:
+            return await self.send_cog_help(cog)
 
         # If it's not a cog then it's a command.
         # Since we want to have detailed errors when someone
         # passes an invalid subcommand, we need to walk through
         # the command group chain ourselves.
-        keys = command.split(' ')
+        keys = command.split(" ")
         cmd = bot.all_commands.get(keys[0])
         if cmd is None:
-            string = await maybe_coro(self.command_not_found, self.remove_mentions(keys[0]))
+            string = await maybe_coroutine(self.command_not_found, self.remove_mentions(keys[0]))
             return await self.send_error_message(string)
 
         for key in keys[1:]:
             try:
                 found = cmd.all_commands.get(key)  # type: ignore
             except AttributeError:
-                string = await maybe_coro(self.subcommand_not_found, cmd, self.remove_mentions(key))
+                string = await maybe_coroutine(self.subcommand_not_found, cmd, self.remove_mentions(key))
                 return await self.send_error_message(string)
             else:
                 if found is None:
-                    string = await maybe_coro(self.subcommand_not_found, cmd, self.remove_mentions(key))
+                    string = await maybe_coroutine(self.subcommand_not_found, cmd, self.remove_mentions(key))
                     return await self.send_error_message(string)
                 cmd = found
 
@@ -96,11 +94,11 @@ class HornetHelpCommand(HelpCommand):
         else:
             return await self.send_command_help(cmd)
 
-def getParams(cmd: Command):
-    paramstring = ""
-    for name, param in cmd.params.items():
+def get_params(cmd: Command):
+    param_string = ""
+    for param in cmd.params.values():
         if not param.required: 
-            paramstring += f"*<{param.name}>* "
+            param_string += f"*<{param.name}>* "
         else: 
-            paramstring += f"<{param.name}> "
-    return cmd.usage if cmd.usage is not None else paramstring
+            param_string += f"<{param.name}> "
+    return cmd.usage if cmd.usage is not None else param_string

--- a/components/src.py
+++ b/components/src.py
@@ -1,5 +1,5 @@
 import srcomapi
-import srcomapi.datatypes as dt
+from srcomapi.datatypes import Game, Level, Run, User, Variable
 import requests
 
 api = srcomapi.SpeedrunCom()
@@ -14,42 +14,42 @@ DISCORD_VERIFIED_SUFFIX = ' <div data-state="closed"><svg xmlns="http://www.w3.o
 
 class NotFoundException(Exception): pass
 
-def getGame(name: str) -> dt.Game:
+def get_game(name: str) -> Game:
     try:
-        return api.search(dt.Game, {"name": name})[0]
+        return api.search(Game, {"name": name})[0]
     except IndexError:
         raise NotFoundException
 
-def getUnverifiedRuns(game: dt.Game):
+def get_unverified_runs(game: Game):
     """Caps at 200; pagination takes work & you shouldn't have this many unverified runs!"""
-    return api.search(dt.Run, {"game": game.id, "status": "new", "max": 200, "orderby": "submitted", "direction": "asc"})
+    return api.search(Run, {"game": game.id, "status": "new", "max": 200, "orderby": "submitted", "direction": "asc"})
 
-def getRunsFromUser(games : list[dt.Game], user: dt.User):
+def get_runs_from_user(games: list[Game], user: User):
     """Get a list of verified runs from the user for a given list of games"""
     runs = []
     for game in games:
-        runs += api.search(dt.Run, {"game": game.id, "status": "verified", "user": user.id})
+        runs += api.search(Run, {"game": game.id, "status": "verified", "user": user.id})
     return runs
 
-def getCategory(id):
-    return dt.Run(api, data=api.get(f"categories/{id}"))
+def get_category(id):
+    return Run(api, data=api.get(f"categories/{id}"))
 
-def getUser(id):
-    return dt.User(api, data=api.get(f"users/{id}"))
+def get_user(id):
+    return User(api, data=api.get(f"users/{id}"))
 
-def getVariable(id):
-    return dt.Variable(api, data=api.get(f"variables/{id}"))
+def get_variable(id):
+    return Variable(api, data=api.get(f"variables/{id}"))
 
-def getLevel(id):
-    return dt.Level(api, data=api.get(f"levels/{id}"))
+def get_level(id):
+    return Level(api, data=api.get(f"levels/{id}"))
 
-def findUser(name):
+def find_user(name):
     try:
-        return api.search(dt.User, {"name": name})[0]
+        return api.search(User, {"name": name})[0]
     except IndexError:
         raise NotFoundException
-    
-def getDiscord(user: dt.User) -> str:
+
+def get_discord(user: User) -> str:
     """Gets the discord username of a speedrun.com User."""
     # The SRC api does not contain the discord username from the user profile, so we're scraping it instead. This is stupid.
     get = requests.get(f"http://www.speedrun.com/user/{user.name}") # not safe but idc anymore

--- a/modules/gameTracking.py
+++ b/modules/gameTracking.py
@@ -1,10 +1,11 @@
-import discord
-from discord.ext import commands, tasks
-import srcomapi.datatypes as dt
+from discord import TextChannel, RawReactionActionEvent
+from discord.ext.commands import Bot, Cog, Context, command
+from discord.ext.tasks import loop
+from srcomapi.datatypes import Game, Run
 from datetime import timedelta
-import logging, time
+import logging
 
-from components import src, auth, emojiUtil
+from components import auth, emojiUtil, src
 import save
 
 MODULE_NAME = __name__.split(".")[-1]
@@ -15,150 +16,150 @@ MODULE_TEMPLATE = {
     "unclaimEmoji": "\u274C"
 }
 
-async def setup(bot: commands.Bot):
-    save.addModuleTemplate(MODULE_NAME, MODULE_TEMPLATE)
-    await bot.add_cog(gameTrackerCog(bot))
+async def setup(bot: Bot):
+    save.add_module_template(MODULE_NAME, MODULE_TEMPLATE)
+    await bot.add_cog(GameTrackerCog(bot))
 
-async def teardown(bot: commands.Bot):
+async def teardown(bot: Bot):
     await bot.remove_cog("GameTracking")
 
-class gameTrackerCog(commands.Cog, name="GameTracking", description="Module tracking verification queues on speedrun.com"):
-    def __init__(self, bot: commands.Bot):
+class GameTrackerCog(Cog, name="GameTracking", description="Module tracking verification queues on speedrun.com"):
+    def __init__(self, bot: Bot):
         self.bot = bot
         self.updateGames.start()
-    
+
     def cog_unload(self):
         self.updateGames.cancel()
 
-    @commands.command(help="Register a channel to track unverified runs for a game.")
-    @commands.check(auth.isAdmin)
-    async def addgame(self, context: commands.Context, channel : discord.TextChannel, *, gamename):
-        save.getModuleData(context.guild.id, MODULE_NAME)["channels"].append({str(channel.id): gamename})
+    @command(help="Register a channel to track unverified runs for a game.")
+    @auth.check_admin
+    async def addgame(self, context: Context, channel: TextChannel, *, gamename):
+        save.get_module_data(context.guild.id, MODULE_NAME)["channels"].append({str(channel.id): gamename})
         save.save()
         await context.message.delete()
 
-    @commands.command(help="Unregister a channel from tracking unverified runs for this game.")
-    @commands.check(auth.isAdmin)
-    async def removegame(self, context: commands.Context, channel : discord.TextChannel, *, gamename):
-        save.getModuleData(context.guild.id, MODULE_NAME)["channels"].remove({str(channel.id): gamename})
+    @command(help="Unregister a channel from tracking unverified runs for this game.")
+    @auth.check_admin
+    async def removegame(self, context: Context, channel: TextChannel, *, gamename):
+        save.get_module_data(context.guild.id, MODULE_NAME)["channels"].remove({str(channel.id): gamename})
         save.save()
         await context.message.delete()
 
-    @commands.command(help="Sets emoji used for claims (will not clear old reacts!)")
-    @commands.check(auth.isAdmin)
-    async def setClaimEmoji(self, context: commands.Context, emoji : str):
-        emoji = await emojiUtil.toEmoji(context, emoji)
-        emoji_ref = emojiUtil.toString(emoji)
-        save.getModuleData(context.guild.id, MODULE_NAME)["claimEmoji"] = emoji_ref
+    @command(help="Sets emoji used for claims (will not clear old reacts!)")
+    @auth.check_admin
+    async def setClaimEmoji(self, context: Context, emoji: str):
+        emoji = await emojiUtil.to_emoji(context, emoji)
+        emoji_ref = emojiUtil.to_string(emoji)
+        save.get_module_data(context.guild.id, MODULE_NAME)["claimEmoji"] = emoji_ref
         save.save()
         await context.message.delete()
 
-    @commands.command(help="Sets emoji used for unclaims (will not clear old reacts!)")
-    @commands.check(auth.isAdmin)
-    async def setUnclaimEmoji(self, context: commands.Context, emoji : str):
-        emoji = await emojiUtil.toEmoji(context, emoji)
-        emoji_ref = emojiUtil.toString(emoji)
-        save.getModuleData(context.guild.id, MODULE_NAME)["unclaimEmoji"] = emoji_ref
+    @command(help="Sets emoji used for unclaims (will not clear old reacts!)")
+    @auth.check_admin
+    async def setUnclaimEmoji(self, context: Context, emoji: str):
+        emoji = await emojiUtil.to_emoji(context, emoji)
+        emoji_ref = emojiUtil.to_string(emoji)
+        save.get_module_data(context.guild.id, MODULE_NAME)["unclaimEmoji"] = emoji_ref
         save.save()
         await context.message.delete()
 
-    @commands.Cog.listener()
-    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
+    @Cog.listener()
+    async def on_raw_reaction_add(self, payload: RawReactionActionEvent):
         """Handler on adding reacts in tracked verifier channels"""
-        modData = save.getModuleData(payload.guild_id, MODULE_NAME)
-        if str(payload.channel_id) not in [list(x.keys())[0] for x in modData["channels"]]: return
+        mod_data = save.get_module_data(payload.guild_id, MODULE_NAME)
+        if str(payload.channel_id) not in [list(x.keys())[0] for x in mod_data["channels"]]: return
         if payload.user_id == self.bot.user.id: return
 
         message = await self.bot.get_channel(payload.channel_id).fetch_message(payload.message_id)
-        refstring = emojiUtil.toString(payload.emoji)
-        reactions = list(filter(lambda x: emojiUtil.toString(x.emoji) == refstring, message.reactions))
+        refstring = emojiUtil.to_string(payload.emoji)
+        reactions = list(filter(lambda x: emojiUtil.to_string(x.emoji) == refstring, message.reactions))
         reaction = reactions[0]
         reacters = []
         async for user in reaction.users():
             if user.id != self.bot.user.id: reacters.append(user)
 
-        if len(reacters) == 0: return
+        if not reacters: return
 
-        if refstring == modData["claimEmoji"]: 
+        if refstring == mod_data["claimEmoji"]: 
             if message.content.endswith("**"): return # don't claim if run already claimed
             
             await message.edit(content=f"{reaction.message.content}\r\n**Claimed by {self.bot.get_user(payload.user_id).name}**")
-            await message.add_reaction(modData["unclaimEmoji"])
+            await message.add_reaction(mod_data["unclaimEmoji"])
             await reaction.clear()
-        elif refstring == modData["unclaimEmoji"]:
+        elif refstring == mod_data["unclaimEmoji"]:
             if message.content.endswith(">"): return # don't unclaim if run is already unclaimed
             name = message.content.splitlines()[-1].split(" ")[-1].removesuffix("**")
             if name != self.bot.get_user(payload.user_id).name: return
 
             await message.edit(content="\r\n".join(message.content.splitlines()[:-1])) # Cut off verifier line
-            await message.add_reaction(modData["claimEmoji"])
+            await message.add_reaction(mod_data["claimEmoji"])
             await reaction.clear()
 
     #TODO: add indicator for better times in same category
-    @tasks.loop(minutes=1)
+    @loop(minutes=1)
     async def updateGames(self):
         """Check tracked channels for games"""
         logging.log(logging.DEBUG, "updateGames running...")
         try:
-            for guildID in save.data["guilds"].keys():
-                modData = save.getModuleData(guildID, MODULE_NAME)
-                claimEmoji = modData["claimEmoji"]
-                unclaimEmoji = modData["unclaimEmoji"]
-                for singletonDict in modData["channels"]:
-                    channelID = list(singletonDict.keys())[0]
-                    game = src.getGame(singletonDict[channelID])
-                    channel = self.bot.get_channel(int(channelID))
+            for guild_id in save.data["guilds"]:
+                mod_data = save.get_module_data(guild_id, MODULE_NAME)
+                claim_emoji = mod_data["claimEmoji"]
+                unclaim_emoji = mod_data["unclaimEmoji"]
+                for singleton_dict in mod_data["channels"]:
+                    channel_id = list(singleton_dict.keys())[0]
+                    game = src.get_game(singleton_dict[channel_id])
+                    channel = self.bot.get_channel(int(channel_id))
                     messages = channel.history(limit=200, oldest_first=True)
-                    unverified = src.getUnverifiedRuns(game)
+                    unverified = src.get_unverified_runs(game)
 
                     # Collate messages to Run IDs
-                    messageRuns = {}
+                    message_runs = {}
                     async for m in messages:
                         if m.author.id != self.bot.user.id: continue # skip non-bot messages
-                        messageRuns[m] = m.content.splitlines()[1].split("/")[-1][:-1] # get id from url in message (also slicing trailing >)
+                        message_runs[m] = m.content.splitlines()[1].split("/")[-1][:-1] # get id from url in message (also slicing trailing >)
                     # Post new runs
                     for run in unverified:
-                        if run.id not in messageRuns.values():
+                        if run.id not in message_runs.values():
                             await self.postRun(channel, run, game)
                     # Remove stale runs
-                    for m, runId in messageRuns.items():
+                    for m, runId in message_runs.items():
                         if runId not in [run.id for run in unverified]:
                             await m.delete()
                     # Ensure runs are reacted to (doing this on post risks reacts not actually getting added)
                     messages = channel.history(limit=200, oldest_first=True)
                     async for m in messages:
                         if m.content.endswith(">"):
-                            if claimEmoji not in [r.emoji for r in m.reactions]:
-                                await m.add_reaction(claimEmoji)
+                            if claim_emoji not in [r.emoji for r in m.reactions]:
+                                await m.add_reaction(claim_emoji)
                         else: # run is claimed, ensure it has remove react
-                            if unclaimEmoji not in [r.emoji for r in m.reactions]:
-                                await m.add_reaction(unclaimEmoji)
+                            if unclaim_emoji not in [r.emoji for r in m.reactions]:
+                                await m.add_reaction(unclaim_emoji)
         except Exception as e:
             logging.log(logging.ERROR, "GameTracking.updateGames task failed! Ignoring...")
             logging.log(logging.ERROR, e, exc_info=True)
-    
-    async def postRun(self, channel: discord.TextChannel, run: dt.Run, game: dt.Game):
-        playernames = {p.name.lower() for p in run.players}
-        tag = "" if playernames.isdisjoint(save.getGuildData(channel.guild.id)["spoileredPlayers"]) else "||"
-        await channel.send(f"`{game.name}: {categoryName(run)}` in {formatTime(run.times['primary_t'])} by {tag}{run.players[0].name}{tag}\r\n<{run.weblink}>")
 
-def categoryName(run: dt.Run):
-    cat = src.getCategory(run.category)
+    async def postRun(self, channel: TextChannel, run: Run, game: Game):
+        player_names = { player.name.lower() for player in run.players }
+        tag = "" if player_names.isdisjoint(save.get_guild_data(channel.guild.id)["spoileredPlayers"]) else "||"
+        await channel.send(f"`{game.name}: {get_category_name(run)}` in {format_time(run.times['primary_t'])} by {tag}{run.players[0].name}{tag}\r\n<{run.weblink}>")
+
+def get_category_name(run: Run):
+    cat = src.get_category(run.category)
 
     subcatname = ""
-    for varid in list(run.values.keys()):
-        var = src.getVariable(varid)
-        if var.is_subcategory: 
+    for varid in run.values:
+        var = src.get_variable(varid)
+        if var.is_subcategory:
             subcatname = f" - {var.values['values'][run.values[varid]]['label']}"
             break
-    
+
     if cat.type == "per-level":
-        level = src.getLevel(run.level)
+        level = src.get_level(run.level)
         return f"{level.name}{subcatname}"
 
     return f"{cat.name}{subcatname}"
 
-def formatTime(time):
+def format_time(time):
     td = str(timedelta(seconds=time))
     if "." in td: td = td[:td.index(".") + 3] # Strip microseconds if present bc timedelta shows micro- rather than milli-
     while td.startswith("0") or td.startswith(":"):

--- a/modules/module_guide.md
+++ b/modules/module_guide.md
@@ -1,12 +1,12 @@
 # Adding Modules
 
-To add a module (discord.py [extension](https://discordpy.readthedocs.io/en/stable/ext/commands/extensions.html#ext-commands-extensions)), place any loading code into a global `async def setup(bot):`. Note this function must be present (even if it does nothing) for the extension to load. This will be called on bot-admin calls to `reloadExtensions`.
+To add a module (discord.py [extension](https://discordpy.readthedocs.io/en/stable/ext/commands/extensions.html#ext-commands-extensions)), place any loading code into a global `async def setup(bot):`. Note this function must be present (even if it does nothing) for the extension to load. This will be called on bot-admin calls to `reloadModules`.
 
 Please add commands as a `Cog` unless the module is meant to explicitly extend base functionality. This will provide commands in a submenu of `help`. You can use a `GroupCog` for commands to be added as subcommands, while `Cog` commands will be called as normal.
 
 ## Persistence
 
-If you need to persist data, use `save.addModuleTemplate(module_name, init_data)` with a dictionary of default values - this will be copied into each guild on use. This dictionary of stored values can be accessed using `save.getModuleData(guild_id, module_name)`. After writing values, call `save.save()` to persist to disk.
+If you need to persist data, use `save.add_module_template(module_name, init_data)` with a dictionary of default values - this will be copied into each guild on use. This dictionary of stored values can be accessed using `save.get_module_data(guild_id, module_name)`. After writing values, call `save.save()` to persist to disk.
 
 module_name must be `__name__.split(".")[-1]` (the filename as it is loaded by Hornet, minus the `modules.` prefix) as this is used to check & enforce the save templates. You can name your `Cog` separately if you want a nicer name to display in the `help` cmd - just don't add spaces.
 

--- a/modules/srroles.py
+++ b/modules/srroles.py
@@ -1,95 +1,98 @@
-import discord
-from discord.ext import commands
-from discord.ext.commands import Context
-from srcomapi import datatypes as dt
+from discord import Role
+from discord.ext.commands import Bot, Cog, Context, command
+from srcomapi.datatypes import Game
 import logging
 
-from components import src, auth, embeds
+from components import auth, embeds, src
 import save
 
 MODULE_NAME = __name__.split(".")[-1]
 
-async def setup(bot: commands.Bot):
-    save.addModuleTemplate(MODULE_NAME, {"games" : [], "srrole": 0 })
-    await bot.add_cog(srrolesCog(bot))
+async def setup(bot: Bot):
+    save.add_module_template(MODULE_NAME, {"games" : [], "srrole": 0 })
+    await bot.add_cog(SrRolesCog(bot))
 
-async def teardown(bot: commands.Bot):
+async def teardown(bot: Bot):
     await bot.remove_cog("SrcRoles")
 
-class srrolesCog(commands.Cog, name="SrcRoles", description="Commands to verify runners from their SRC profile"):
+class SrRolesCog(Cog, name="SrcRoles", description="Commands to verify runners from their SRC profile"):
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.command(help="Grants the speedrunner role to verified runners given your SRC username", \
-                      aliases=["getsrrole", "grantsrole"])
+    @command(help="Grants the speedrunner role to verified runners given your SRC username",
+             aliases=["getsrrole", "grantsrole"])
     async def grantsrrole(self, context: Context, src_username: str):
         ectx = embeds.EmbedContext(context)
         guild_id = str(context.guild.id)
 
-        srrole_id = save.getModuleData(guild_id, MODULE_NAME)["srrole"]
+        srrole_id = save.get_module_data(guild_id, MODULE_NAME)["srrole"]
         srrole = context.guild.get_role(srrole_id)
         if srrole is None:
-            await ectx.embedReply("SRRoles module is not set up! Ask an admin to use ;setsrrole")
+            await ectx.embed_reply("SRRoles module is not set up! Ask an admin to use ;setsrrole")
             return
 
-        games = [src.getGame(game) for game in save.getModuleData(guild_id, MODULE_NAME)["games"]]
+        games = [src.get_game(game) for game in save.get_module_data(guild_id, MODULE_NAME)["games"]]
         try:
-            user = src.findUser(src_username)
+            user = src.find_user(src_username)
         except src.NotFoundException:
-            await ectx.embedReply(f"No SRC user with name {src_username}")
+            await ectx.embed_reply(f"No SRC user with name {src_username}")
             return
 
         try:
-            dc = src.getDiscord(user)
+            dc = src.get_discord(user)
         except src.NotFoundException:
-            await ectx.embedReply(f"Please link your discord in your Speedrun.com profile")
+            await ectx.embed_reply(f"Please link your discord in your Speedrun.com profile")
             return
 
-        if context.author.discriminator != "0": discordname = f"{context.author.name}#{context.author.discriminator}"
-        else: discordname = context.author.name
-        if dc.lower() != discordname.lower():
-            logging.warn(f"SRC name: {dc} != Discord name: {discordname}")
-            await ectx.embedReply(f"Your Discord username doesn't match SRC! Update the Discord username on your SRC profile to `{discordname}`")
+        discord_name = context.author.name
+        if context.author.discriminator != "0":
+            discord_name += f"#{context.author.discriminator}"
+        if dc.lower() != discord_name.lower():
+            logging.warn(f"SRC name: {dc} != Discord name: {discord_name}")
+            await ectx.embed_reply(f"Your Discord username doesn't match SRC! Update the Discord username on your SRC profile to `{discord_name}`")
             return
 
-        runs = src.getRunsFromUser(games, user)
+        runs = src.get_runs_from_user(games, user)
 
         if len(runs) > 0:
             if srrole in context.author.roles:
-                await ectx.embedReply("You are already verified")
+                await ectx.embed_reply("You are already verified")
             else:
                 await context.author.add_roles(srrole)
-                await ectx.embedReply(f"Runner {src_username} verified")
+                await ectx.embed_reply(f"Runner {src_username} verified")
         else:
-            await ectx.embedReply("You must have a verified run on speedrun.com!")
+            await ectx.embed_reply("You must have a verified run on speedrun.com!")
 
-    @commands.command(help="Set the role given by ;grantsrrole")
-    @commands.check(auth.isAdmin)
-    async def setsrrole(self, context: Context, role: discord.Role):
-        save.getModuleData(context.guild.id, MODULE_NAME)["srrole"] = role.id
+    @command(help="Set the role given by ;grantsrrole")
+    @auth.check_admin
+    async def setsrrole(self, context: Context, role: Role):
+        save.get_module_data(context.guild.id, MODULE_NAME)["srrole"] = role.id
         save.save()
-        await embeds.embedReply(context, f"Speedrun role set to {role.name}")
+        await embeds.embed_reply(context, f"Speedrun role set to {role.name}")
 
-    @commands.command(help="Sets up games for runner role. Supply game names in quotes.")
-    @commands.check(auth.isAdmin)
+    @command(help="Sets up games for runner role. Supply game names in quotes.")
+    @auth.check_admin
     async def setsrgames(self, context: Context, *game_names: str):
-        games : list[dt.Game] = []
+        games : list[Game] = []
         not_found = []
         for game_name in game_names:
             try:
-                games.append(src.getGame(game_name))
+                games.append(src.get_game(game_name))
             except src.NotFoundException:
                 not_found.append(game_name)
 
-        save.getModuleData(context.guild.id, MODULE_NAME)["games"] = [game.name for game in games]
+        save.get_module_data(context.guild.id, MODULE_NAME)["games"] = [game.name for game in games]
         save.save()
 
         games = [g.name for g in games]
-        await embeds.embedReply(context, message=("Verified:\r\n" + '\r\n'.join(games) + \
-                                                   (f"\r\n\r\nCould not find: \r\n {' '.join(not_found)}" if len(not_found) != 0 else '')))
+        await embeds.embed_reply(
+            context,
+            message=("Verified:\r\n" + '\r\n'.join(games) + \
+                     (f"\r\n\r\nCould not find: \r\n {' '.join(not_found)}" if len(not_found) != 0 else ''))
+        )
 
-    @commands.command(help="Get the list of games the speedrunner role checks for runs with")
+    @command(help="Get the list of games the speedrunner role checks for runs with")
     async def listsrgames(self, context: Context):
         ectx = embeds.EmbedContext(context)
-        games = save.getModuleData(context.guild.id, "srroles")["games"]
-        await ectx.embedReply(title= "Verified Games:", message="\r\n".join(games))
+        games = save.get_module_data(context.guild.id, "srroles")["games"]
+        await ectx.embed_reply(title= "Verified Games:", message="\r\n".join(games))

--- a/save.py
+++ b/save.py
@@ -41,45 +41,46 @@ else:
             logging.error(f"Save json is out of date! Json ver: {data['version']} < Save ver: {VERSION}")
             exit(11)
 
-def addModuleTemplate(module_name: str, init_data: dict):
+def add_module_template(module_name: str, init_data: dict):
     data["module_templates"][module_name] = copy.deepcopy(init_data)
     save()
 
-def enforceTemplateDict(target: dict, template: dict):
+def enforce_template_dict(target: dict, template: dict):
     """Recursive method to enforce a module save template. Verifies only by type. Does not remove extra keys.
-    
-    Raises `TemplateEnforcementError` if existing key type differs."""
-    for k in template.keys():
-        if k not in target.keys(): 
-            target[k] = template[k]
-            continue
-        if type(target[k]) != type(template[k]): raise TemplateEnforcementError(k)
-        if type(target[k]) == dict: enforceTemplateDict(target[k], template[k])
 
-def getGuildIds() -> list[str]:
+    Raises `TemplateEnforcementError` if existing key type differs."""
+    for k, template_value in template.items():
+        target_value = target.get(k, None)
+        if target_value is None:
+            target[k] = template_value
+            continue
+        if type(target_value) != type(template_value): raise TemplateEnforcementError(k)
+        if isinstance(target_value, dict): enforce_template_dict(target_value, template_value)
+
+def get_guild_ids() -> list[str]:
     return data["guilds"].keys()
 
-def getModuleData(guild_id, module_name):
-    return getGuildData(guild_id)["modules"][module_name]
+def get_module_data(guild_id, module_name):
+    return get_guild_data(guild_id)["modules"][module_name]
 
-def getGuildData(guild_id):
+def get_guild_data(guild_id):
     if str(guild_id) not in data["guilds"].keys():
-        initGuildData(guild_id)
+        init_guild_data(guild_id)
     return data["guilds"][str(guild_id)]
 
-def initGuildData(guild_id : str, guild_name : str = ""):
+def init_guild_data(guild_id : str, guild_name : str = ""):
     data["guilds"][guild_id] = FULL_TEMPLATE
     data["guilds"][guild_id]["nick"] = guild_name
     data["guilds"][guild_id]["modules"] = copy.deepcopy(data["module_templates"])
 
-def initModule(module_name, init_data=None):
+def init_module(module_name, init_data=None):
     if init_data is None:
         if module_name not in data["module_templates"]: return # No template added by module, ignore it
         init_data = data["module_templates"][module_name]
-    for guild_id in getGuildIds():
-        modules = getGuildData(guild_id)["modules"]
+    for guild_id in get_guild_ids():
+        modules = get_guild_data(guild_id)["modules"]
         if module_name in modules:
-            enforceTemplateDict(modules[module_name], init_data)
+            enforce_template_dict(modules[module_name], init_data)
         else:
             modules[module_name] = copy.deepcopy(init_data)
     save()


### PR DESCRIPTION
Various formatting updates to more closely follow Python formatting standards:
- Switched most non-command identifiers to snake case
- Switched Cog child class names to Pascal case
- Removed unnecessary / trailing whitespace
- Removed unused imports & cleaned up imports
- Removed unnecessary line continuations (`\`) & added a few line breaks for readability of long method calls

Also a few refactors & tweaks:
- `embeds.py`: factored out repeated logic in `embed*` methods
- Added `Check` decorators to `auth.py` to reduce duplication of `@check(predicate)` pattern
- Some small refactors when looping through `dict`s / checking keys

> I am become Python, the destroyer of camelCase