### PR TITLE
make listCustomCommands just print the commands

### DIFF
--- a/src/modules/customCommands.py
+++ b/src/modules/customCommands.py
@@ -88,11 +88,8 @@ class CustomCommandsCog(Cog, name="CustomCommands", description="Handles adding 
     async def listCustomCommands(self, context: 'HornetContext'):
         if context.guild is None: return
         mod_data = save.get_module_data(context.guild.id, MODULE_NAME)
-        msgstr = ""
-        for cmd, response in sorted(mod_data.items()):
-            response = escape_chars(response)
-            msgstr += f";{cmd} | {response if len(response) < 50 else (response[:60] + '...')}\r\n"
-
+        command_keys = {k.lower() for k in mod_data}
+        msgstr = " ".join(sorted(command_keys))
         await context.embed_reply(title="Custom commands:", message=msgstr)
 
 def escape_chars(message):


### PR DESCRIPTION
Since I don't have an integration set up, I tested the following code:
```py
def get_module_data():
    return {
        "Foo": "hello",
        "bar": "goodbye"
    }

def listCustomCommands():
    mod_data = get_module_data()
    command_keys = { k.lower() for k in mod_data }
    msgstr = " ".join(sorted(command_keys))
    return msgstr

print(listCustomCommands())
```

and it printed `bar foo`